### PR TITLE
Handle overnight time restrictions in airspace utilities

### DIFF
--- a/src/services/AirspaceDataService.ts
+++ b/src/services/AirspaceDataService.ts
@@ -125,8 +125,9 @@ export class AirspaceDataService {
         const endTimeMinutes = endHour * 60 + endMinute;
 
         const isDayActive = restriction.daysOfWeek.includes(currentDay);
-        const isTimeActive = currentTimeMinutes >= startTimeMinutes && 
-                           currentTimeMinutes <= endTimeMinutes;
+        const isTimeActive = startTimeMinutes <= endTimeMinutes
+          ? currentTimeMinutes >= startTimeMinutes && currentTimeMinutes <= endTimeMinutes
+          : currentTimeMinutes >= startTimeMinutes || currentTimeMinutes <= endTimeMinutes;
 
         return isDayActive && isTimeActive;
       });

--- a/src/utils/timeUtils.ts
+++ b/src/utils/timeUtils.ts
@@ -67,7 +67,9 @@ export class TimeCalculator {
             const startTimeMinutes = startHour * 60 + startMinute;
             const endTimeMinutes = endHour * 60 + endMinute;
 
-            return currentTimeMinutes >= startTimeMinutes && currentTimeMinutes <= endTimeMinutes;
+            return startTimeMinutes <= endTimeMinutes
+                ? currentTimeMinutes >= startTimeMinutes && currentTimeMinutes <= endTimeMinutes
+                : currentTimeMinutes >= startTimeMinutes || currentTimeMinutes <= endTimeMinutes;
         } catch (error) {
             console.error('Error checking time range:', error);
             return false;


### PR DESCRIPTION
## Summary
- fix `isAirspaceActive` to correctly detect restrictions that span midnight
- update `TimeCalculator.isTimeInRange` for overnight ranges

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install --no-audit --no-fund` *(fails: ENOTEMPTY: directory not empty, rename)*

------
https://chatgpt.com/codex/tasks/task_e_68ac1fdbf4f4832795b5203309cd7779