### PR TITLE
Improve UI contrast and map transitions

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -102,9 +102,9 @@ function App() {
   };
 
   return (
-    <div className="w-screen h-screen relative bg-gray-50 overflow-hidden">
+    <div className="w-screen h-screen relative bg-gray-100 text-gray-900 overflow-hidden">
       {/* Background Pattern */}
-      <div className="absolute inset-0 bg-gradient-to-br from-blue-50 via-white to-indigo-50 opacity-30 z-0"></div>
+      <div className="absolute inset-0 bg-gradient-to-br from-blue-100 via-gray-200 to-indigo-100 opacity-50 z-0"></div>
 
       <AirspaceMap
         layerVisibility={layerVisibility}

--- a/src/components/Charts/DemandCapacityChart.tsx
+++ b/src/components/Charts/DemandCapacityChart.tsx
@@ -60,16 +60,16 @@ export const DemandCapacityChart: React.FC<DemandCapacityChartProps> = ({
     margin: { l: 40, r: 20, t: 20, b: 40 },
     paper_bgcolor: 'rgba(255,255,255,0)',
     plot_bgcolor: 'rgba(255,255,255,0)',
-    font: { color: '#374151', size: 10 },
+    font: { color: '#1f2937', size: 12 },
     xaxis: {
-      gridcolor: 'rgba(0,0,0,0.1)',
-      tickfont: { size: 9, color: '#6b7280' },
+      gridcolor: 'rgba(0,0,0,0.2)',
+      tickfont: { size: 11, color: '#374151' },
       showgrid: true,
       zeroline: false
     },
     yaxis: {
-      gridcolor: 'rgba(0,0,0,0.1)',
-      tickfont: { size: 9, color: '#6b7280' },
+      gridcolor: 'rgba(0,0,0,0.2)',
+      tickfont: { size: 11, color: '#374151' },
       showgrid: true,
       zeroline: false
     },
@@ -77,7 +77,7 @@ export const DemandCapacityChart: React.FC<DemandCapacityChartProps> = ({
       x: 0,
       y: 1,
       bgcolor: 'rgba(255,255,255,0)',
-      font: { size: 9, color: '#374151' }
+      font: { size: 11, color: '#1f2937' }
     },
     showlegend: true,
     hovermode: 'x unified' as const

--- a/src/components/Map/AirspaceMap.tsx
+++ b/src/components/Map/AirspaceMap.tsx
@@ -76,7 +76,11 @@ export const AirspaceMap: React.FC<AirspaceMapProps> = ({
         const map = L.map('map', {
             center: MAP_CONFIG.center,
             zoom: MAP_CONFIG.zoom,
-            zoomControl: false
+            zoomControl: false,
+            fadeAnimation: true,
+            zoomAnimation: true,
+            zoomSnap: 0.5,
+            zoomDelta: 0.5
         });
 
         // Add base layer

--- a/src/index.css
+++ b/src/index.css
@@ -6,9 +6,10 @@
   line-height: 1.5;
   font-weight: 400;
 
-  color-scheme: light dark;
-  color: rgba(255, 255, 255, 0.87);
-  background-color: #242424;
+  /* Default to a light theme with strong contrast */
+  color-scheme: light;
+  color: #1f2937; /* gray-800 */
+  background-color: #f3f4f6; /* gray-100 */
 
   font-synthesis: none;
   text-rendering: optimizeLegibility;
@@ -59,8 +60,8 @@ button:focus-visible {
 
 @media (prefers-color-scheme: light) {
   :root {
-    color: #213547;
-    background-color: #ffffff;
+    color: #1f2937;
+    background-color: #f3f4f6;
   }
   a:hover {
     color: #747bff;


### PR DESCRIPTION
## Summary
- use light-themed root styles for better readability
- strengthen background gradient and text contrast
- increase chart font sizes and grid contrast
- enable smoother map zoom and fade animations

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68ac20763dc88327b1f88ab3be0d2d53